### PR TITLE
fix missing redirect in test_data/Makefile

### DIFF
--- a/test_data/Makefile
+++ b/test_data/Makefile
@@ -21,7 +21,7 @@ cdr1as_test.bam: bt2_cdr1as_locus.4.bt2 cdr1as_reads.fa
 	@printf "\n>>> aligning example reads\n\n"
 	bowtie2 -p8 --very-sensitive --score-min=C,-15,0 --reorder --mm \
 		-f -U cdr1as_reads.fa -x bt2_cdr1as_locus \
-		2> bt2_firstpass.log | samtools view -hbuS - | samtools sort - cdr1as_test
+		2> bt2_firstpass.log | samtools view -hbuS - | samtools sort - > cdr1as_test
 
 unmapped_cdr1as_test.bam: cdr1as_test.bam
 	@printf "\n>>> fetching the unmapped reads\n\n"


### PR DESCRIPTION
When running `make` in `test_data` to check the installation of `find_circ` I did, I ran into this:

```
>>> building bowtie2 index

bowtie2-build CDR1as_locus.fa bt2_cdr1as_locus > bt2_build.log 2>&1;

>>> aligning example reads

bowtie2 -p8 --very-sensitive --score-min=C,-15,0 --reorder --mm \
	-f -U cdr1as_reads.fa -x bt2_cdr1as_locus \
	2> bt2_firstpass.log | samtools view -hbuS - | samtools sort - cdr1as_test
[bam_sort] Use -T PREFIX / -o FILE to specify temporary and final output files
Usage: samtools sort [options...] [in.bam]
Options:
  -l INT     Set compression level, from 0 (uncompressed) to 9 (best)
  -m INT     Set maximum memory per thread; suffix K/M/G recognized [768M]
  -n         Sort by read name
  -t TAG     Sort by value of TAG. Uses position as secondary index (or read name if -n is set)
  -o FILE    Write final output to FILE rather than standard output
  -T PREFIX  Write temporary files to PREFIX.nnnn.bam
      --input-fmt-option OPT[=VAL]
               Specify a single input file format option in the form
               of OPTION or OPTION=VALUE
  -O, --output-fmt FORMAT[,OPT[=VAL]]...
               Specify output format (SAM, BAM, CRAM)
      --output-fmt-option OPT[=VAL]
               Specify a single output file format option in the form
               of OPTION or OPTION=VALUE
      --reference FILE
               Reference sequence FASTA FILE [null]
  -@, --threads INT
               Number of additional threads to use [0]
[E::bgzf_close] File write failed
samtools view: error closing standard output: -1
make: *** [cdr1as_test.bam] Error 1
```

It seems like this is just a missing redirect `cdr1as_test.bam` `Makefile` target.

Not sure if it matters at all, but I was using SAMtools 1.6, maybe there was a change to recent SAMtools versions that requires this?